### PR TITLE
EditorScreen 3カラム化: A4プレビュー常時表示・インライン編集

### DIFF
--- a/src/app/RedactPro.tsx
+++ b/src/app/RedactPro.tsx
@@ -5798,12 +5798,12 @@ function EditorScreen({data,onReset,apiKey,model}){
   const buildCsv=()=>"種類,カテゴリ,検出値,検出方法,確信度,マスク有無\n"+detections.map(d=>`"${d.label}","${d.category}","${d.value}","${d.source}","${d.confidence||""}","${d.enabled?"マスク済":"未マスク"}"`).join("\n");
 
   // A4プレビュー用 memoized HTML
-  const previewSrcText=editedText||redacted;
+  const previewSrcText=editedText??redacted;
   const previewHtml=useMemo(()=>editMode?generatePDFHTML(previewSrcText,previewFontType):"",[editMode,previewSrcText,previewFontType]);
 
   // 共通エクスポートヘルパー
   const exportPrintPDF=useCallback(()=>{
-    const src=editedText||redacted;
+    const src=editedText??redacted;
     const html=generatePDFHTML(src,previewFontType);
     const printHTML=html.replace("</body>",`<script>window.onload=function(){window.print();setTimeout(()=>{window.close()},1000)}<\/script></body>`);
     const blob=new Blob([printHTML],{type:"text/html;charset=utf-8"});
@@ -5814,7 +5814,7 @@ function EditorScreen({data,onReset,apiKey,model}){
   },[editedText,redacted,previewFontType]);
 
   const exportHTML=useCallback(()=>{
-    const src=editedText||redacted;
+    const src=editedText??redacted;
     const html=generatePDFHTML(src,previewFontType);
     const blob=new Blob([html],{type:"text/html;charset=utf-8"});
     const a=document.createElement("a");const url=URL.createObjectURL(blob);
@@ -5823,7 +5823,7 @@ function EditorScreen({data,onReset,apiKey,model}){
   },[editedText,redacted,previewFontType,baseName]);
 
   const exportWord=useCallback(()=>{
-    const src=editedText||redacted;
+    const src=editedText??redacted;
     const html=generatePDFHTML(src,previewFontType);
     const wordHTML=html.replace('<!DOCTYPE html>','').replace('<html lang="ja">','<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns="http://www.w3.org/TR/REC-html40" lang="ja">').replace('<head>','<head><!--[if gte mso 9]><xml><w:WordDocument><w:View>Print</w:View><w:Zoom>100</w:Zoom></w:WordDocument></xml><![endif]-->');
     const blob=new Blob(["\uFEFF"+wordHTML],{type:"application/msword;charset=utf-8"});
@@ -6187,7 +6187,7 @@ function EditorScreen({data,onReset,apiKey,model}){
                           <span style={{opacity:0.6,marginLeft:8}}>Markdown記法でA4プレビューに反映</span>
                       </div>
                       <textarea
-                          value={editedText||""}
+                          value={editedText??""}
                           onChange={(e)=>setEditedText(e.target.value)}
                           spellCheck={false}
                           style={{
@@ -6345,7 +6345,7 @@ function EditorScreen({data,onReset,apiKey,model}){
           <div
               className='rp-editor-right'
               style={{
-                  flex: previewVisible ? '0 0 260' : '1 1 44%',
+                  flex: previewVisible ? '0 0 260px' : '1 1 44%',
                   display: sidebarCollapsed?'none':'flex',
                   flexDirection: 'column',
                   minWidth: 240,
@@ -6889,7 +6889,7 @@ function EditorScreen({data,onReset,apiKey,model}){
           )}
           {showDesign && (
               <DesignExportModal
-                  text={viewMode === 'ai' && aiResult ? aiResult : redacted}
+                  text={editMode ? (editedText??redacted) : viewMode === 'ai' && aiResult ? aiResult : redacted}
                   apiKey={apiKey}
                   model={model}
                   baseName={baseName}


### PR DESCRIPTION
## Summary

- EditorScreenを2カラムから3カラム構成に変更（テキスト / A4プレビュー / 検出サイドバー）
- A4プレビューパネルを常時表示に変更（折りたたみ可能）
- インライン編集モードを追加: textareaで直接テキスト編集、A4プレビューがリアルタイム連動
- 編集モード時のエクスポート機能（PDF印刷・HTML・Word）をプレビューツールバーに配置
- 全画面編集への遷移ボタンを追加（既存DesignExportModal連携）

Closes #3

## Test plan

- [ ] テキストファイルをアップロードし、EditorScreen遷移後にA4プレビューが常時表示されることを確認
- [ ] 「編集」ボタンで左パネルがtextareaに切り替わることを確認
- [ ] textarea編集時にA4プレビューがリアルタイム更新されることを確認
- [ ] フォント切替（ゴシック/明朝）が反映されることを確認
- [ ] エクスポート（PDF印刷/HTML/Word）が正常動作することを確認
- [ ] A4プレビューパネルの折りたたみ/展開が正常に動作することを確認
- [ ] サイドバーの折りたたみと併用してもレイアウトが崩れないことを確認
- [ ] 検出結果クリックでテキスト箇所へスクロール（非編集モード時）が動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ドキュメント編集機能を追加しました。Markdown風の編集ペインでテキストを直接編集・プレビューできます。
  * A4プレビューパネルにフォント切り替え機能を追加（ゴシック/明朝）。
  * PDF、HTML、Word形式へのエクスポート機能を実装しました。
  * レスポンシブレイアウトが改善され、プレビュー表示時の画面構成が最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->