### PR TITLE
4ステップフロー再構成でユーザー導線を明確化

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -88,11 +88,12 @@ test.describe('PreviewModal', () => {
     await page.getByRole('button', { name: '次へ: 書き出す' }).click()
     await expect(page.locator('[role="dialog"]')).toBeVisible()
 
-    // 最大化ボタン
-    const expandBtn = page.getByRole('button', { name: '最大化' })
+    // 最大化ボタン（背後の整えるビューにも「縮小」ズームボタンがあるためダイアログ内にスコープ）
+    const dialog = page.getByRole('dialog')
+    const expandBtn = dialog.getByRole('button', { name: '最大化' })
     if ((await expandBtn.count()) > 0) {
       await expandBtn.click()
-      await expect(page.getByRole('button', { name: '縮小' })).toBeVisible()
+      await expect(dialog.getByRole('button', { name: '縮小' })).toBeVisible()
     }
   })
 })

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -80,19 +80,19 @@ test.describe('PreviewModal', () => {
     // EditorScreen のツアーオーバーレイを除去
     await dismissTour(page)
 
-    // プレビューボタンをクリック
-    const previewBtn = page.getByRole('button', { name: /プレビュー/ })
-    if ((await previewBtn.count()) > 0) {
-      await previewBtn.first().click()
-      // モーダルが開く
-      await expect(page.locator('[role="dialog"]')).toBeVisible()
+    // 確認する → 整える（A4プレビュー画面）
+    await page.getByRole('button', { name: '次へ: 整える' }).click()
+    await expect(page.getByText('A4 プレビュー')).toBeVisible()
 
-      // 最大化ボタン
-      const expandBtn = page.getByRole('button', { name: '最大化' })
-      if ((await expandBtn.count()) > 0) {
-        await expandBtn.click()
-        await expect(page.getByRole('button', { name: '縮小' })).toBeVisible()
-      }
+    // 整える → 書き出す（エクスポートプレビューモーダル）
+    await page.getByRole('button', { name: '次へ: 書き出す' }).click()
+    await expect(page.locator('[role="dialog"]')).toBeVisible()
+
+    // 最大化ボタン
+    const expandBtn = page.getByRole('button', { name: '最大化' })
+    if ((await expandBtn.count()) > 0) {
+      await expandBtn.click()
+      await expect(page.getByRole('button', { name: '縮小' })).toBeVisible()
     }
   })
 })

--- a/src/app/RedactPro.tsx
+++ b/src/app/RedactPro.tsx
@@ -48,7 +48,7 @@ import * as Papa from "papaparse";
 import * as XLSX from "xlsx";
 import { clearAllSiteData } from "../lib/storage";
 import { StepFlowBar } from "@/components/StepFlowBar";
-import { getCurrentFlowStep, FLOW_EVENT_SET_EXPORT, FLOW_EVENT_EXPORT_STATE, FLOW_EVENT_ANALYZING } from "@/lib/flow-steps";
+import { getCurrentFlowStep, FLOW_EVENT_SET_EXPORT, FLOW_EVENT_EXPORT_STATE, FLOW_EVENT_ANALYZING, FLOW_EVENT_SET_MODE, FLOW_EVENT_MODE_STATE } from "@/lib/flow-steps";
 
 // ═══ Theme System (CSS Custom Properties) ═══
 const C={accent:"#1C1917",accentDim:"rgba(28,25,23,0.08)",red:"#DC2626",redDim:"rgba(220,38,38,0.1)",green:"#059669",greenDim:"rgba(5,150,105,0.1)",amber:"#D97706",amberDim:"rgba(217,119,6,0.1)",purple:"#9B6DFF",purpleDim:"rgba(155,109,255,0.1)",cyan:"#22D3EE",cyanDim:"rgba(34,211,238,0.1)",sumi:"#1C1917",washi:"#FAF9F6",stamp:"#DC2626",font:"'Noto Sans JP','DM Sans',system-ui,sans-serif",mono:"'JetBrains Mono','Fira Code',monospace"};
@@ -5415,7 +5415,8 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
   },[]);
   const[editMode,setEditMode]=useState(false);
   const[editedText,setEditedText]=useState(null);
-  const[previewVisible,setPreviewVisible]=useState(true);
+  // 確認ステップはテキスト+検出リストに集中させる（A4プレビューは「整える」ステップが主役）
+  const[previewVisible,setPreviewVisible]=useState(false);
   const[previewFontType,setPreviewFontType]=useState("gothic");
   const[previewZoom,setPreviewZoom]=useState(1);
   // Draggable panel widths (percentages of total width)
@@ -5584,6 +5585,19 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
     window.dispatchEvent(new CustomEvent(FLOW_EVENT_EXPORT_STATE,{detail:{open:!!preview}}));
     return()=>{window.dispatchEvent(new CustomEvent(FLOW_EVENT_EXPORT_STATE,{detail:{open:false}}));};
   },[preview]);
+  // ── ステップフロー: 確認する(review) / 整える(format) のモード切替 ──
+  const[flowMode,setFlowMode]=useState('review');
+  useEffect(()=>{
+    const handler=(e)=>{const m=e.detail?.mode;if(m==='review'||m==='format')setFlowMode(m);};
+    window.addEventListener(FLOW_EVENT_SET_MODE,handler);
+    return()=>window.removeEventListener(FLOW_EVENT_SET_MODE,handler);
+  },[]);
+  useEffect(()=>{
+    window.dispatchEvent(new CustomEvent(FLOW_EVENT_MODE_STATE,{detail:{mode:flowMode}}));
+    return()=>{window.dispatchEvent(new CustomEvent(FLOW_EVENT_MODE_STATE,{detail:{mode:'review'}}));};
+  },[flowMode]);
+  const goFormat=useCallback(()=>setFlowMode('format'),[]);
+  const goReview=useCallback(()=>setFlowMode('review'),[]);
   const buildCsv=()=>"種類,カテゴリ,検出値,検出方法,確信度,マスク有無\n"+detections.map(d=>`"${d.label}","${d.category}","${d.value}","${d.source}","${d.confidence||""}","${d.enabled?"マスク済":"未マスク"}"`).join("\n");
 
   // A4プレビュー用 memoized HTML
@@ -5746,6 +5760,143 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
     }
     return '1fr 36px 40px';
   },[isLite,previewVisible,sidebarCollapsed,leftPct,rightPct,centerCol]);
+
+  // ── 整えるステップ: A4プレビューを主役にした専用ビュー（Lite/Pro共通） ──
+  if(flowMode==='format'){
+    return (
+      <div className='rp-editor-wrap' style={{display:'flex',flexDirection:'column',height:'calc(100vh - 52px - 40px - 36px)',minHeight:0,fontFamily:T.font,background:T.bg}}>
+          <div className={s['ed-preview-toolbar']}>
+              <span className={s['ed-preview-label']}>A4 プレビュー</span>
+              {!isLite && (
+                  <button
+                      onClick={()=>{
+                          if(!editMode){setEditedText(viewMode==="ai"&&aiResult?aiResult:redacted);setEditMode(true);}
+                          else{setEditMode(false);setEditedText(null);}
+                      }}
+                      title='テキストを直接編集してA4プレビューに反映'
+                      className={s['ed-small-btn']}
+                      style={{
+                          border:`1px solid ${editMode?T.accent:T.border}`,
+                          background:editMode?T.accentDim:'transparent',
+                          color:editMode?T.accent:T.text3,fontWeight:editMode?600:400,
+                      }}
+                  >{editMode?'編集を終了':'テキストを編集'}</button>
+              )}
+              {!isLite && editMode && (
+                  <>
+                      <button onClick={()=>setPreviewFontType("gothic")} title="ゴシック体に切替" className={s['ed-small-btn']}
+                          style={{
+                              border:`1px solid ${previewFontType==="gothic"?T.accent:T.border}`,
+                              background:previewFontType==="gothic"?T.accentDim:"transparent",
+                              color:previewFontType==="gothic"?T.accent:T.text3,fontWeight:previewFontType==="gothic"?600:400,
+                          }}>ゴシック</button>
+                      <button onClick={()=>setPreviewFontType("mincho")} title="明朝体に切替" className={s['ed-small-btn']}
+                          style={{
+                              border:`1px solid ${previewFontType==="mincho"?T.accent:T.border}`,
+                              background:previewFontType==="mincho"?T.accentDim:"transparent",
+                              color:previewFontType==="mincho"?T.accent:T.text3,fontWeight:previewFontType==="mincho"?600:400,
+                          }}>明朝</button>
+                  </>
+              )}
+              <div style={{display:"flex",alignItems:"center",gap:2,marginLeft:4}}>
+                  <button onClick={()=>setPreviewZoom(z=>Math.max(0.3,+(z-0.1).toFixed(2)))} title="縮小" aria-label="縮小" className={s['ed-zoom-btn']}>&minus;</button>
+                  <button onClick={()=>setPreviewZoom(1)} title="ズームをリセット" aria-label="ズームをリセット" className={s['ed-zoom-label']}>{Math.round(previewZoom*100)}%</button>
+                  <button onClick={()=>setPreviewZoom(z=>Math.min(1.5,+(z+0.1).toFixed(2)))} title="拡大" aria-label="拡大" className={s['ed-zoom-btn']}>+</button>
+              </div>
+              <span style={{flex:1}}/>
+              {!isLite && (
+                  <button onClick={()=>setShowAI(true)} title='AIで推薦書・スキルシート等の形式に自動整形' className={s['ed-small-btn']}
+                      style={{border:`1px solid ${T.border}`,background:'transparent',color:T.text2}}>AI で再フォーマット</button>
+              )}
+              {!isLite && <button onClick={()=>setShowDesign(true)} title="全画面編集" aria-label="全画面編集" className={s['ed-small-icon-btn']}>&#x2197;</button>}
+          </div>
+          <div style={{flex:1,minHeight:0,display:'flex',background:'#e5e7eb',overflow:'hidden'}}>
+              {!isLite && editMode && (
+                  <div style={{width:'38%',minWidth:280,display:'flex',flexDirection:'column',borderRight:`1px solid ${T.border}`,background:T.bg,minHeight:0}}>
+                      <div className={s['ed-edit-hint']}>
+                          <span style={{fontWeight:600,color:T.text2}}>記法: </span>
+                          <code className={s['ed-edit-code']}>**太字**</code>
+                          <code className={s['ed-edit-code']} style={{marginLeft:6}}># 見出し</code>
+                          <span style={{opacity:0.6,marginLeft:8}}>A4プレビューに即反映</span>
+                      </div>
+                      <textarea
+                          aria-label="Markdown編集"
+                          value={editedText??""}
+                          onChange={(e)=>setEditedText(e.target.value)}
+                          spellCheck={false}
+                          className={s['ed-edit-textarea']}
+                      />
+                  </div>
+              )}
+              <div style={{flex:1,minWidth:0,display:'flex',flexDirection:'column',overflow:'hidden'}}>
+                  {!isLite && editMode ? (
+                      <div style={{flex:1,overflow:"auto",display:"flex",justifyContent:"center",padding:16}}>
+                          <div style={{width:Math.round(595*previewZoom),flexShrink:0}}>
+                              <div style={{width:595,minHeight:842,background:"#fff",boxShadow:"0 4px 24px rgba(0,0,0,.12)",borderRadius:4,transform:`scale(${previewZoom})`,transformOrigin:"top left"}}>
+                                  <iframe
+                                      srcDoc={previewHtml}
+                                      sandbox="allow-same-origin"
+                                      style={{width:"100%",minHeight:842,border:"none",pointerEvents:"none"}}
+                                      title="A4 Preview"
+                                      onLoad={(e)=>{try{const h=e.target.contentDocument?.documentElement?.scrollHeight;if(h&&h>842)e.target.style.height=h+"px";}catch(ex){}}}
+                                  />
+                              </div>
+                          </div>
+                      </div>
+                  ) : (
+                      <A4PreviewPanel
+                          text={aiResult||data.text_preview}
+                          detections={detections}
+                          maskOpts={data.maskOpts}
+                          focusDetId={focusDetId}
+                          focusPulse={focusPulse}
+                          onFocusDet={focusDetection}
+                          zoom={previewZoom}
+                      />
+                  )}
+              </div>
+          </div>
+          <div style={{display:'flex',gap:8,padding:'10px 14px',borderTop:`1px solid ${T.border}`,background:T.bg2,flexShrink:0,alignItems:'center'}}>
+              <Btn variant='ghost' onClick={goReview} title='検出結果の確認に戻る' style={{borderRadius:10,fontSize:13}}>&larr; 確認に戻る</Btn>
+              <span style={{flex:1,fontSize:12,color:T.text3}}>仕上がりを確認できたら書き出しへ</span>
+              <Btn onClick={openExportPreview} title='マスキング結果を確認して書き出す' style={{borderRadius:10,fontSize:13,background:T.accent,padding:'11px 22px'}}>次へ: 書き出す</Btn>
+          </div>
+          {showAI && (
+              <AIPanel
+                  redactedText={redacted}
+                  apiKey={apiKey}
+                  model={model}
+                  onApply={(t) => {
+                      setAiResult(t)
+                      setViewMode('ai')
+                      setShowAI(false)
+                  }}
+                  onClose={() => setShowAI(false)}
+              />
+          )}
+          {showDesign && (
+              <DesignExportModal
+                  text={editMode ? (editedText??redacted) : viewMode === 'ai' && aiResult ? aiResult : redacted}
+                  apiKey={apiKey}
+                  model={model}
+                  baseName={baseName}
+                  onClose={() => setShowDesign(false)}
+              />
+          )}
+          {preview && (
+              <PreviewModal
+                  title={preview.title}
+                  content={preview.content}
+                  baseName={preview.baseName}
+                  editable={preview.editable}
+                  meta={preview.meta}
+                  onClose={() => setPreview(null)}
+                  onContentChange={preview.onContentChange}
+              />
+          )}
+      </div>
+    );
+  }
 
   return (
       <div
@@ -6631,52 +6782,14 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
                   data-intro="export-buttons"
                   className={s['ed-footer']}
               >
-                  {!isLite && <Btn
-                      data-intro="ai-reformat"
-                      title='AIでテキストを再整形'
-                      onClick={() => setShowAI(true)}
-                      style={{
-                          width: '100%',
-                          borderRadius: 10,
-                          background: 'transparent',
-                          fontSize: 13,
-                          color: T.accent,
-                          border: `1.5px solid ${T.accent}`,
-                      }}
-                  >
-                      AI で再フォーマット
-                  </Btn>}
-                  {!isLite && <Btn
-                      data-intro="pdf-edit"
-                      title='PDF編集モードを開く'
-                      onClick={() => {
-                          if(!editMode){
-                              setEditedText(viewMode==="ai"&&aiResult?aiResult:redacted);
-                              setEditMode(true);
-                              setPreviewVisible(true);
-                          }else{
-                              setEditMode(false);
-                              setEditedText(null);
-                          }
-                      }}
-                      style={{
-                          width: '100%',
-                          borderRadius: 10,
-                          background: editMode ? T.accent : 'transparent',
-                          fontSize: 13,
-                          color: editMode ? undefined : T.accent,
-                          border: editMode ? 'none' : `1.5px solid ${T.accent}`,
-                      }}
-                  >
-                      {editMode ? '編集完了 / プレビューを閉じる' : 'PDF プレビュー・編集'}
-                  </Btn>}
                   <div className={s['ed-btn-row']}>
                       <Btn
-                          title='マスキング結果を確認して書き出す'
-                          onClick={openExportPreview}
+                          data-intro="go-format"
+                          title='A4プレビューでレイアウトを整える（AI整形・PDF編集もこちら）'
+                          onClick={goFormat}
                           style={{ flex: 1, borderRadius: 10, fontSize: 13, background: T.accent }}
                       >
-                          次へ: 書き出す
+                          次へ: 整える
                       </Btn>
                       <Btn
                           title='クリップボードにコピー'
@@ -7219,29 +7332,38 @@ export default function App(){
   // ── ステップフローバー連携 ──
   const[exportOpen,setExportOpen]=useState(false);
   const[analyzing,setAnalyzing]=useState(false);
+  const[flowFormatMode,setFlowFormatMode]=useState(false);
   useEffect(()=>{
     const onExportState=(e)=>setExportOpen(!!e.detail?.open);
     const onAnalyzing=(e)=>setAnalyzing(!!e.detail?.active);
+    const onModeState=(e)=>setFlowFormatMode(e.detail?.mode==='format');
     window.addEventListener(FLOW_EVENT_EXPORT_STATE,onExportState);
     window.addEventListener(FLOW_EVENT_ANALYZING,onAnalyzing);
+    window.addEventListener(FLOW_EVENT_MODE_STATE,onModeState);
     return()=>{
       window.removeEventListener(FLOW_EVENT_EXPORT_STATE,onExportState);
       window.removeEventListener(FLOW_EVENT_ANALYZING,onAnalyzing);
+      window.removeEventListener(FLOW_EVENT_MODE_STATE,onModeState);
     };
   },[]);
   const hasFlowData=!!data||batchMode;
   // バッチ処理中（編集画面が未表示）はエクスポートプレビューを開けない
   const canFlowExport=!!data||(batchMode&&activeFile?.status==='done'&&!!activeFile?.data);
-  const flowStep=getCurrentFlowStep({hasData:hasFlowData,exportOpen});
+  const flowStep=getCurrentFlowStep({hasData:hasFlowData,exportOpen,formatMode:flowFormatMode});
   const handleFlowStepClick=useCallback((id)=>{
     if(id==='input'){
       if(hasFlowData&&window.confirm('最初からやり直しますか？現在の検出結果は破棄されます。'))goHome();
       return;
     }
     if(!hasFlowData)return;
-    if(id==='export'&&!canFlowExport)return;
-    // review: エクスポートを閉じて確認画面へ / export: エクスポートプレビューを開く
-    window.dispatchEvent(new CustomEvent(FLOW_EVENT_SET_EXPORT,{detail:{open:id==='export'}}));
+    if((id==='format'||id==='export')&&!canFlowExport)return;
+    if(id==='export'){
+      window.dispatchEvent(new CustomEvent(FLOW_EVENT_SET_EXPORT,{detail:{open:true}}));
+      return;
+    }
+    // review / format: エクスポートを閉じて対象モードへ切替
+    window.dispatchEvent(new CustomEvent(FLOW_EVENT_SET_EXPORT,{detail:{open:false}}));
+    window.dispatchEvent(new CustomEvent(FLOW_EVENT_SET_MODE,{detail:{mode:id==='format'?'format':'review'}}));
   },[hasFlowData,canFlowExport,goHome]);
 
   return (

--- a/src/app/RedactPro.tsx
+++ b/src/app/RedactPro.tsx
@@ -5857,9 +5857,9 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
               </div>
           </div>
           <div style={{display:'flex',gap:8,padding:'10px 14px',borderTop:`1px solid ${T.border}`,background:T.bg2,flexShrink:0,alignItems:'center'}}>
-              <Btn variant='ghost' onClick={goReview} title='検出結果の確認に戻る' style={{borderRadius:10,fontSize:13}}>&larr; 確認に戻る</Btn>
+              <Btn variant='ghost' onClick={goReview} aria-label='確認に戻る' title='検出結果の確認に戻る' style={{borderRadius:10,fontSize:13}}>&larr; 確認に戻る</Btn>
               <span style={{flex:1,fontSize:12,color:T.text3}}>仕上がりを確認できたら書き出しへ</span>
-              <Btn onClick={openExportPreview} title='マスキング結果を確認して書き出す' style={{borderRadius:10,fontSize:13,background:T.accent,padding:'11px 22px'}}>次へ: 書き出す</Btn>
+              <Btn onClick={openExportPreview} aria-label='次へ: 書き出す' title='マスキング結果を確認して書き出す' style={{borderRadius:10,fontSize:13,background:T.accent,padding:'11px 22px'}}>次へ: 書き出す</Btn>
           </div>
           {showAI && (
               <AIPanel
@@ -6785,6 +6785,7 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
                   <div className={s['ed-btn-row']}>
                       <Btn
                           data-intro="go-format"
+                          aria-label='次へ: 整える'
                           title='A4プレビューでレイアウトを整える（AI整形・PDF編集もこちら）'
                           onClick={goFormat}
                           style={{ flex: 1, borderRadius: 10, fontSize: 13, background: T.accent }}

--- a/src/app/RedactPro.tsx
+++ b/src/app/RedactPro.tsx
@@ -47,6 +47,8 @@ import * as mammoth from "mammoth";
 import * as Papa from "papaparse";
 import * as XLSX from "xlsx";
 import { clearAllSiteData } from "../lib/storage";
+import { StepFlowBar } from "@/components/StepFlowBar";
+import { getCurrentFlowStep, FLOW_EVENT_SET_EXPORT, FLOW_EVENT_EXPORT_STATE, FLOW_EVENT_ANALYZING } from "@/lib/flow-steps";
 
 // ═══ Theme System (CSS Custom Properties) ═══
 const C={accent:"#1C1917",accentDim:"rgba(28,25,23,0.08)",red:"#DC2626",redDim:"rgba(220,38,38,0.1)",green:"#059669",greenDim:"rgba(5,150,105,0.1)",amber:"#D97706",amberDim:"rgba(217,119,6,0.1)",purple:"#9B6DFF",purpleDim:"rgba(155,109,255,0.1)",cyan:"#22D3EE",cyanDim:"rgba(34,211,238,0.1)",sumi:"#1C1917",washi:"#FAF9F6",stamp:"#DC2626",font:"'Noto Sans JP','DM Sans',system-ui,sans-serif",mono:"'JetBrains Mono','Fira Code',monospace"};
@@ -1948,7 +1950,7 @@ function BatchProcessingView({file}){
   return (
     <div aria-live="polite" aria-label={`${file.fileName}を処理中: ${file.stage||'処理待機中'} ${file.progress||0}%`} style={{
       display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',
-      height:'calc(100vh - 90px)',gap:16,fontFamily:T.font,
+      height:'calc(100vh - 130px)',gap:16,fontFamily:T.font,
     }}>
       <div style={{width:48,height:48,border:`3px solid ${T.border}`,borderTopColor:T.accent,borderRadius:'50%',
         animation:'rp-spin 1s linear infinite'}} role="status" aria-label="処理中"/>
@@ -1967,7 +1969,7 @@ function BatchErrorView({file,onRetry}){
   return (
     <div role="alert" style={{
       display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',
-      height:'calc(100vh - 90px)',gap:12,fontFamily:T.font,
+      height:'calc(100vh - 130px)',gap:12,fontFamily:T.font,
     }}>
       <div style={{width:48,height:48,borderRadius:'50%',background:T.redDim,display:'flex',alignItems:'center',justifyContent:'center',fontSize:24,color:T.red}} aria-hidden="true">!</div>
       <div style={{fontSize:16,fontWeight:600,color:T.text}}>{file.fileName}</div>
@@ -4188,6 +4190,12 @@ function UploadScreen({onAnalyze,onSubmitBatch,settings,isLite,onSwitchPro}){
     return()=>clearInterval(id);
   },[loading]);
 
+  // 解析中状態をステップフローバーへ通知
+  useEffect(()=>{
+    window.dispatchEvent(new CustomEvent(FLOW_EVENT_ANALYZING,{detail:{active:loading}}));
+    return()=>{window.dispatchEvent(new CustomEvent(FLOW_EVENT_ANALYZING,{detail:{active:false}}));};
+  },[loading]);
+
   useEffect(()=>{(async()=>{try{const v=await safeGet("rp_custom_keywords");if(v){const parsed=JSON.parse(v);if(Array.isArray(parsed))setCustomKeywords(parsed);}}catch(e){}finally{kwLoadedRef.current=true;}})();},[]);
   useEffect(()=>{if(kwLoadedRef.current)storage.set("rp_custom_keywords",JSON.stringify(customKeywords));},[customKeywords]);
 
@@ -5554,7 +5562,28 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
   // アドバイザー: 改善テキストを却下
   const handleAdvisorDraftReject=useCallback(()=>{setAdvisorDraft(null);},[]);
 
-  const buildTxt=()=>viewMode==="ai"&&aiResult?aiResult:redacted;
+  // エクスポートプレビューを開く（フッターのボタンとステップフローバーの両方から呼ばれる）
+  const openExportPreview=useCallback(()=>{
+    setPreview({
+      title:'マスキング済みテキスト',
+      content:viewMode==="ai"&&aiResult?aiResult:redacted,
+      baseName,
+      editable:true,
+      meta:{fileName:data.file_name,maskCount:enabledCount,xlMeta:data.xlMeta?.map(sh=>({sheetName:sh.sheetName,aoa:sh.aoa.map(r=>r.map(c=>applyRedaction(String(c??""),detections,data.maskOpts)))}))},
+      onContentChange:(newContent)=>{setPreview(prev=>prev?{...prev,content:newContent}:null)},
+    });
+  },[viewMode,aiResult,redacted,baseName,data,enabledCount,detections]);
+  // ステップフローバーからのエクスポート開閉指示
+  useEffect(()=>{
+    const handler=(e)=>{if(e.detail?.open)openExportPreview();else setPreview(null);};
+    window.addEventListener(FLOW_EVENT_SET_EXPORT,handler);
+    return()=>window.removeEventListener(FLOW_EVENT_SET_EXPORT,handler);
+  },[openExportPreview]);
+  // エクスポートプレビューの開閉状態をステップフローバーへ通知（アンマウント時はクローズ扱い）
+  useEffect(()=>{
+    window.dispatchEvent(new CustomEvent(FLOW_EVENT_EXPORT_STATE,{detail:{open:!!preview}}));
+    return()=>{window.dispatchEvent(new CustomEvent(FLOW_EVENT_EXPORT_STATE,{detail:{open:false}}));};
+  },[preview]);
   const buildCsv=()=>"種類,カテゴリ,検出値,検出方法,確信度,マスク有無\n"+detections.map(d=>`"${d.label}","${d.category}","${d.value}","${d.source}","${d.confidence||""}","${d.enabled?"マスク済":"未マスク"}"`).join("\n");
 
   // A4プレビュー用 memoized HTML
@@ -5724,7 +5753,7 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
           style={{
               display: 'grid',
               gridTemplateColumns: gridCols,
-              height: 'calc(100vh - 52px - 36px)',
+              height: 'calc(100vh - 52px - 40px - 36px)',
               fontFamily: T.font,
               transition: presetTransRef.current ? 'grid-template-columns .2s ease' : undefined,
           }}
@@ -6609,8 +6638,10 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
                       style={{
                           width: '100%',
                           borderRadius: 10,
-                          background: T.accent,
+                          background: 'transparent',
                           fontSize: 13,
+                          color: T.accent,
+                          border: `1.5px solid ${T.accent}`,
                       }}
                   >
                       AI で再フォーマット
@@ -6641,23 +6672,11 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
                   </Btn>}
                   <div className={s['ed-btn-row']}>
                       <Btn
-                          title='マスキング結果をプレビュー'
-                          variant='ghost'
-                          onClick={() =>
-                              setPreview({
-                                  title: 'マスキング済みテキスト',
-                                  content: buildTxt(),
-                                  baseName,
-                                  editable: true,
-                                  meta: { fileName: data.file_name, maskCount: enabledCount, xlMeta: data.xlMeta?.map(s=>({sheetName:s.sheetName,aoa:s.aoa.map(r=>r.map(c=>applyRedaction(String(c??""),detections,data.maskOpts)))})) },
-                                  onContentChange: (newContent) => {
-                                      setPreview(prev => prev ? {...prev, content: newContent} : null)
-                                  },
-                              })
-                          }
-                          style={{ flex: 1, borderRadius: 10, fontSize: 13 }}
+                          title='マスキング結果を確認して書き出す'
+                          onClick={openExportPreview}
+                          style={{ flex: 1, borderRadius: 10, fontSize: 13, background: T.accent }}
                       >
-                          プレビュー / 保存
+                          次へ: 書き出す
                       </Btn>
                       <Btn
                           title='クリップボードにコピー'
@@ -7197,6 +7216,31 @@ export default function App(){
   const batchMode=batchFiles.length>0;
   const activeFile=batchFiles[activeFileIdx];
 
+  // ── ステップフローバー連携 ──
+  const[exportOpen,setExportOpen]=useState(false);
+  const[analyzing,setAnalyzing]=useState(false);
+  useEffect(()=>{
+    const onExportState=(e)=>setExportOpen(!!e.detail?.open);
+    const onAnalyzing=(e)=>setAnalyzing(!!e.detail?.active);
+    window.addEventListener(FLOW_EVENT_EXPORT_STATE,onExportState);
+    window.addEventListener(FLOW_EVENT_ANALYZING,onAnalyzing);
+    return()=>{
+      window.removeEventListener(FLOW_EVENT_EXPORT_STATE,onExportState);
+      window.removeEventListener(FLOW_EVENT_ANALYZING,onAnalyzing);
+    };
+  },[]);
+  const hasFlowData=!!data||batchMode;
+  const flowStep=getCurrentFlowStep({hasData:hasFlowData,exportOpen});
+  const handleFlowStepClick=useCallback((id)=>{
+    if(id==='input'){
+      if(hasFlowData&&window.confirm('最初からやり直しますか？現在の検出結果は破棄されます。'))goHome();
+      return;
+    }
+    if(!hasFlowData)return;
+    // review: エクスポートを閉じて確認画面へ / export: エクスポートプレビューを開く
+    window.dispatchEvent(new CustomEvent(FLOW_EVENT_SET_EXPORT,{detail:{open:id==='export'}}));
+  },[hasFlowData,goHome]);
+
   return (
       <div
           data-theme={isDark ? 'dark' : 'light'}
@@ -7316,6 +7360,7 @@ export default function App(){
                   </button>
               </div>
           </header>
+          <StepFlowBar current={flowStep} hasData={hasFlowData} analyzing={analyzing} onStepClick={handleFlowStepClick}/>
           <main style={{flex:1,display:'flex',flexDirection:'column',overflow:'hidden'}}>
           {(!isLite && batchMode) ? (
               <>

--- a/src/app/RedactPro.tsx
+++ b/src/app/RedactPro.tsx
@@ -5566,13 +5566,13 @@ function EditorScreen({data,onReset,apiKey,model,isLite}){
   const openExportPreview=useCallback(()=>{
     setPreview({
       title:'マスキング済みテキスト',
-      content:viewMode==="ai"&&aiResult?aiResult:redacted,
+      content:editedText??(viewMode==="ai"&&aiResult?aiResult:redacted),
       baseName,
       editable:true,
       meta:{fileName:data.file_name,maskCount:enabledCount,xlMeta:data.xlMeta?.map(sh=>({sheetName:sh.sheetName,aoa:sh.aoa.map(r=>r.map(c=>applyRedaction(String(c??""),detections,data.maskOpts)))}))},
       onContentChange:(newContent)=>{setPreview(prev=>prev?{...prev,content:newContent}:null)},
     });
-  },[viewMode,aiResult,redacted,baseName,data,enabledCount,detections]);
+  },[editedText,viewMode,aiResult,redacted,baseName,data,enabledCount,detections]);
   // ステップフローバーからのエクスポート開閉指示
   useEffect(()=>{
     const handler=(e)=>{if(e.detail?.open)openExportPreview();else setPreview(null);};
@@ -7230,6 +7230,8 @@ export default function App(){
     };
   },[]);
   const hasFlowData=!!data||batchMode;
+  // バッチ処理中（編集画面が未表示）はエクスポートプレビューを開けない
+  const canFlowExport=!!data||(batchMode&&activeFile?.status==='done'&&!!activeFile?.data);
   const flowStep=getCurrentFlowStep({hasData:hasFlowData,exportOpen});
   const handleFlowStepClick=useCallback((id)=>{
     if(id==='input'){
@@ -7237,9 +7239,10 @@ export default function App(){
       return;
     }
     if(!hasFlowData)return;
+    if(id==='export'&&!canFlowExport)return;
     // review: エクスポートを閉じて確認画面へ / export: エクスポートプレビューを開く
     window.dispatchEvent(new CustomEvent(FLOW_EVENT_SET_EXPORT,{detail:{open:id==='export'}}));
-  },[hasFlowData,goHome]);
+  },[hasFlowData,canFlowExport,goHome]);
 
   return (
       <div
@@ -7360,7 +7363,7 @@ export default function App(){
                   </button>
               </div>
           </header>
-          <StepFlowBar current={flowStep} hasData={hasFlowData} analyzing={analyzing} onStepClick={handleFlowStepClick}/>
+          <StepFlowBar current={flowStep} hasData={hasFlowData} analyzing={analyzing} canExport={canFlowExport} onStepClick={handleFlowStepClick}/>
           <main style={{flex:1,display:'flex',flexDirection:'column',overflow:'hidden'}}>
           {(!isLite && batchMode) ? (
               <>

--- a/src/app/redact-pro.module.css
+++ b/src/app/redact-pro.module.css
@@ -1713,7 +1713,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: calc(100vh - 56px);
+  min-height: calc(100vh - 96px);
   padding: 40px;
   animation: fadeUp 0.4s;
 }
@@ -1843,7 +1843,7 @@
 }
 
 .up-root {
-  min-height: calc(100vh - 56px);
+  min-height: calc(100vh - 96px);
   padding: 32px 40px;
   animation: fadeUp 0.5s ease;
 }

--- a/src/components/StepFlowBar.module.css
+++ b/src/components/StepFlowBar.module.css
@@ -52,7 +52,7 @@
   justify-content: center;
   font-size: 11px;
   font-weight: 700;
-  border: 1.5px solid currentColor;
+  border: 1.5px solid currentcolor;
   flex-shrink: 0;
   box-sizing: border-box;
 }

--- a/src/components/StepFlowBar.module.css
+++ b/src/components/StepFlowBar.module.css
@@ -1,0 +1,124 @@
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--rp-border);
+  background: var(--rp-bg2);
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: none;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--rp-text3);
+  cursor: default;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.step[data-status='current'] {
+  color: var(--rp-accent);
+}
+
+.step[data-status='done'] {
+  color: #059669;
+}
+
+.step[data-clickable='true'] {
+  cursor: pointer;
+}
+
+.step[data-clickable='true']:hover {
+  background: var(--rp-surfaceAlt);
+}
+
+.num {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  border: 1.5px solid currentColor;
+  flex-shrink: 0;
+  box-sizing: border-box;
+}
+
+.step[data-status='current'] .num {
+  background: var(--rp-accent);
+  color: var(--rp-bg);
+  border-color: var(--rp-accent);
+}
+
+.step[data-status='done'] .num {
+  background: rgba(5, 150, 105, 0.12);
+}
+
+.sep {
+  color: var(--rp-text3);
+  opacity: 0.5;
+  flex-shrink: 0;
+  font-size: 11px;
+  user-select: none;
+}
+
+.hint {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--rp-text2);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.hintLabel {
+  font-weight: 700;
+  font-size: 11px;
+  color: var(--rp-text3);
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--rp-surfaceAlt);
+}
+
+.hintText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .hint {
+    display: none;
+  }
+
+  .bar {
+    padding: 0 10px;
+    gap: 4px;
+  }
+
+  .step {
+    padding: 4px 6px;
+  }
+}
+
+@media (max-width: 480px) {
+  .step[data-status='upcoming'] .label,
+  .step[data-status='done'] .label {
+    display: none;
+  }
+}

--- a/src/components/StepFlowBar.tsx
+++ b/src/components/StepFlowBar.tsx
@@ -11,6 +11,8 @@ export interface StepFlowBarProps {
   hasData: boolean
   /** ファイル解析中か */
   analyzing?: boolean
+  /** エクスポートを開ける状態か（省略時は hasData と同じ）。バッチ処理中など編集画面が未表示の間は false にする */
+  canExport?: boolean
   onStepClick: (id: FlowStepId) => void
 }
 
@@ -23,6 +25,7 @@ export function StepFlowBar({
   current,
   hasData,
   analyzing = false,
+  canExport = hasData,
   onStepClick,
 }: StepFlowBarProps) {
   const currentStep = FLOW_STEPS.find((s) => s.id === current)
@@ -35,8 +38,9 @@ export function StepFlowBar({
     <nav aria-label="作業ステップ" data-intro="step-flow" className={styles.bar}>
       {FLOW_STEPS.map((step, i) => {
         const status = getFlowStepStatus(step.id, current)
-        // データがあれば現在地以外のステップへ移動できる（1=やり直し / 3=書き出し）
-        const clickable = status !== 'current' && hasData
+        // データがあれば現在地以外のステップへ移動できる（1=やり直し / 3=書き出し）。
+        // 書き出しはエクスポート可能な状態（編集画面表示中）に限る
+        const clickable = status !== 'current' && (step.id === 'export' ? canExport : hasData)
         return (
           <Fragment key={step.id}>
             {i > 0 && (
@@ -56,8 +60,12 @@ export function StepFlowBar({
                   ? step.action
                   : step.id === 'input' && hasData
                     ? '最初からやり直す'
-                    : step.id === 'export' && hasData
-                      ? 'エクスポート画面を開く'
+                    : step.id === 'export'
+                      ? canExport
+                        ? 'エクスポート画面を開く'
+                        : hasData
+                          ? '解析が完了すると書き出せます'
+                          : step.action
                       : step.action
               }
               onClick={() => {

--- a/src/components/StepFlowBar.tsx
+++ b/src/components/StepFlowBar.tsx
@@ -11,14 +11,14 @@ export interface StepFlowBarProps {
   hasData: boolean
   /** ファイル解析中か */
   analyzing?: boolean
-  /** エクスポートを開ける状態か（省略時は hasData と同じ）。バッチ処理中など編集画面が未表示の間は false にする */
+  /** 整える/書き出すへ進める状態か（省略時は hasData と同じ）。バッチ処理中など編集画面が未表示の間は false にする */
   canExport?: boolean
   onStepClick: (id: FlowStepId) => void
 }
 
 /**
  * ヘッダー直下に常時表示するステップフローバー。
- * 「1 取り込む → 2 確認する → 3 書き出す」の現在地と、
+ * 「1 取り込む → 2 確認する → 3 整える → 4 書き出す」の現在地と、
  * いまやるべきことを一目で示す。
  */
 export function StepFlowBar({
@@ -38,9 +38,10 @@ export function StepFlowBar({
     <nav aria-label="作業ステップ" data-intro="step-flow" className={styles.bar}>
       {FLOW_STEPS.map((step, i) => {
         const status = getFlowStepStatus(step.id, current)
-        // データがあれば現在地以外のステップへ移動できる（1=やり直し / 3=書き出し）。
-        // 書き出しはエクスポート可能な状態（編集画面表示中）に限る
-        const clickable = status !== 'current' && (step.id === 'export' ? canExport : hasData)
+        // データがあれば現在地以外のステップへ移動できる（1=やり直し）。
+        // 整える/書き出すは編集画面が表示されている状態に限る
+        const needsEditor = step.id === 'format' || step.id === 'export'
+        const clickable = status !== 'current' && (needsEditor ? canExport : hasData)
         return (
           <Fragment key={step.id}>
             {i > 0 && (
@@ -60,13 +61,11 @@ export function StepFlowBar({
                   ? step.action
                   : step.id === 'input' && hasData
                     ? '最初からやり直す'
-                    : step.id === 'export'
-                      ? canExport
+                    : needsEditor && hasData && !canExport
+                      ? '解析が完了すると進めます'
+                      : step.id === 'export' && canExport
                         ? 'エクスポート画面を開く'
-                        : hasData
-                          ? '解析が完了すると書き出せます'
-                          : step.action
-                      : step.action
+                        : step.action
               }
               onClick={() => {
                 if (clickable) onStepClick(step.id)

--- a/src/components/StepFlowBar.tsx
+++ b/src/components/StepFlowBar.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { Fragment } from 'react'
+import { FLOW_GOAL, FLOW_STEPS, getFlowStepStatus, type FlowStepId } from '@/lib/flow-steps'
+import styles from './StepFlowBar.module.css'
+
+export interface StepFlowBarProps {
+  /** 現在のステップ */
+  current: FlowStepId
+  /** 解析済みデータがあるか（ステップ2/3へ進めるか） */
+  hasData: boolean
+  /** ファイル解析中か */
+  analyzing?: boolean
+  onStepClick: (id: FlowStepId) => void
+}
+
+/**
+ * ヘッダー直下に常時表示するステップフローバー。
+ * 「1 取り込む → 2 確認する → 3 書き出す」の現在地と、
+ * いまやるべきことを一目で示す。
+ */
+export function StepFlowBar({
+  current,
+  hasData,
+  analyzing = false,
+  onStepClick,
+}: StepFlowBarProps) {
+  const currentStep = FLOW_STEPS.find((s) => s.id === current)
+  const hint =
+    analyzing && current === 'input'
+      ? '解析中です。完了すると自動で次のステップに進みます'
+      : (currentStep?.action ?? '')
+
+  return (
+    <nav aria-label="作業ステップ" data-intro="step-flow" className={styles.bar}>
+      {FLOW_STEPS.map((step, i) => {
+        const status = getFlowStepStatus(step.id, current)
+        // データがあれば現在地以外のステップへ移動できる（1=やり直し / 3=書き出し）
+        const clickable = status !== 'current' && hasData
+        return (
+          <Fragment key={step.id}>
+            {i > 0 && (
+              <span className={styles.sep} aria-hidden="true">
+                →
+              </span>
+            )}
+            <button
+              type="button"
+              className={styles.step}
+              data-status={status}
+              data-clickable={clickable}
+              aria-current={status === 'current' ? 'step' : undefined}
+              disabled={!clickable && status !== 'current'}
+              title={
+                status === 'current'
+                  ? step.action
+                  : step.id === 'input' && hasData
+                    ? '最初からやり直す'
+                    : step.id === 'export' && hasData
+                      ? 'エクスポート画面を開く'
+                      : step.action
+              }
+              onClick={() => {
+                if (clickable) onStepClick(step.id)
+              }}
+              style={{ opacity: !clickable && status === 'upcoming' ? 0.55 : 1 }}
+            >
+              <span className={styles.num} aria-hidden="true">
+                {status === 'done' ? '✓' : step.num}
+              </span>
+              <span className={styles.label}>{step.label}</span>
+            </button>
+          </Fragment>
+        )
+      })}
+      <span className={styles.hint} title={`ゴール: ${FLOW_GOAL}`}>
+        <span className={styles.hintLabel}>
+          {analyzing && current === 'input' ? '状態' : 'いまやること'}
+        </span>
+        <span className={styles.hintText}>{hint}</span>
+      </span>
+    </nav>
+  )
+}

--- a/src/lib/__tests__/flow-steps.test.ts
+++ b/src/lib/__tests__/flow-steps.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest'
 import { FLOW_STEPS, FLOW_GOAL, getCurrentFlowStep, getFlowStepStatus } from '../flow-steps'
 
 describe('FLOW_STEPS', () => {
-  it('取り込む→確認する→書き出すの3ステップが順番に定義されている', () => {
-    expect(FLOW_STEPS.map((s) => s.id)).toEqual(['input', 'review', 'export'])
-    expect(FLOW_STEPS.map((s) => s.num)).toEqual([1, 2, 3])
+  it('取り込む→確認する→整える→書き出すの4ステップが順番に定義されている', () => {
+    expect(FLOW_STEPS.map((s) => s.id)).toEqual(['input', 'review', 'format', 'export'])
+    expect(FLOW_STEPS.map((s) => s.num)).toEqual([1, 2, 3, 4])
   })
 
   it('各ステップにラベルとアクション説明がある', () => {
@@ -23,14 +23,24 @@ describe('getCurrentFlowStep', () => {
   it('データがなければ常に input', () => {
     expect(getCurrentFlowStep({ hasData: false, exportOpen: false })).toBe('input')
     expect(getCurrentFlowStep({ hasData: false, exportOpen: true })).toBe('input')
+    expect(getCurrentFlowStep({ hasData: false, exportOpen: false, formatMode: true })).toBe(
+      'input',
+    )
   })
 
   it('データがあれば review', () => {
     expect(getCurrentFlowStep({ hasData: true, exportOpen: false })).toBe('review')
   })
 
-  it('エクスポートプレビュー表示中は export', () => {
+  it('整えるモード中は format', () => {
+    expect(getCurrentFlowStep({ hasData: true, exportOpen: false, formatMode: true })).toBe(
+      'format',
+    )
+  })
+
+  it('エクスポートプレビュー表示中は format より export を優先', () => {
     expect(getCurrentFlowStep({ hasData: true, exportOpen: true })).toBe('export')
+    expect(getCurrentFlowStep({ hasData: true, exportOpen: true, formatMode: true })).toBe('export')
   })
 })
 
@@ -38,18 +48,28 @@ describe('getFlowStepStatus', () => {
   it('現在地より前は done、現在地は current、後は upcoming', () => {
     expect(getFlowStepStatus('input', 'review')).toBe('done')
     expect(getFlowStepStatus('review', 'review')).toBe('current')
+    expect(getFlowStepStatus('format', 'review')).toBe('upcoming')
     expect(getFlowStepStatus('export', 'review')).toBe('upcoming')
   })
 
-  it('input が現在地なら残り2つは upcoming', () => {
+  it('input が現在地なら残りはすべて upcoming', () => {
     expect(getFlowStepStatus('input', 'input')).toBe('current')
     expect(getFlowStepStatus('review', 'input')).toBe('upcoming')
+    expect(getFlowStepStatus('format', 'input')).toBe('upcoming')
     expect(getFlowStepStatus('export', 'input')).toBe('upcoming')
   })
 
-  it('export が現在地なら前2つは done', () => {
+  it('format が現在地なら前2つは done、export は upcoming', () => {
+    expect(getFlowStepStatus('input', 'format')).toBe('done')
+    expect(getFlowStepStatus('review', 'format')).toBe('done')
+    expect(getFlowStepStatus('format', 'format')).toBe('current')
+    expect(getFlowStepStatus('export', 'format')).toBe('upcoming')
+  })
+
+  it('export が現在地なら前3つは done', () => {
     expect(getFlowStepStatus('input', 'export')).toBe('done')
     expect(getFlowStepStatus('review', 'export')).toBe('done')
+    expect(getFlowStepStatus('format', 'export')).toBe('done')
     expect(getFlowStepStatus('export', 'export')).toBe('current')
   })
 })

--- a/src/lib/__tests__/flow-steps.test.ts
+++ b/src/lib/__tests__/flow-steps.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { FLOW_STEPS, FLOW_GOAL, getCurrentFlowStep, getFlowStepStatus } from '../flow-steps'
+
+describe('FLOW_STEPS', () => {
+  it('取り込む→確認する→書き出すの3ステップが順番に定義されている', () => {
+    expect(FLOW_STEPS.map((s) => s.id)).toEqual(['input', 'review', 'export'])
+    expect(FLOW_STEPS.map((s) => s.num)).toEqual([1, 2, 3])
+  })
+
+  it('各ステップにラベルとアクション説明がある', () => {
+    for (const step of FLOW_STEPS) {
+      expect(step.label.length).toBeGreaterThan(0)
+      expect(step.action.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('ゴールが定義されている', () => {
+    expect(FLOW_GOAL.length).toBeGreaterThan(0)
+  })
+})
+
+describe('getCurrentFlowStep', () => {
+  it('データがなければ常に input', () => {
+    expect(getCurrentFlowStep({ hasData: false, exportOpen: false })).toBe('input')
+    expect(getCurrentFlowStep({ hasData: false, exportOpen: true })).toBe('input')
+  })
+
+  it('データがあれば review', () => {
+    expect(getCurrentFlowStep({ hasData: true, exportOpen: false })).toBe('review')
+  })
+
+  it('エクスポートプレビュー表示中は export', () => {
+    expect(getCurrentFlowStep({ hasData: true, exportOpen: true })).toBe('export')
+  })
+})
+
+describe('getFlowStepStatus', () => {
+  it('現在地より前は done、現在地は current、後は upcoming', () => {
+    expect(getFlowStepStatus('input', 'review')).toBe('done')
+    expect(getFlowStepStatus('review', 'review')).toBe('current')
+    expect(getFlowStepStatus('export', 'review')).toBe('upcoming')
+  })
+
+  it('input が現在地なら残り2つは upcoming', () => {
+    expect(getFlowStepStatus('input', 'input')).toBe('current')
+    expect(getFlowStepStatus('review', 'input')).toBe('upcoming')
+    expect(getFlowStepStatus('export', 'input')).toBe('upcoming')
+  })
+
+  it('export が現在地なら前2つは done', () => {
+    expect(getFlowStepStatus('input', 'export')).toBe('done')
+    expect(getFlowStepStatus('review', 'export')).toBe('done')
+    expect(getFlowStepStatus('export', 'export')).toBe('current')
+  })
+})

--- a/src/lib/flow-steps.ts
+++ b/src/lib/flow-steps.ts
@@ -1,0 +1,73 @@
+/**
+ * 作業ステップフロー定義
+ *
+ * 「取り込む → 確認する → 書き出す」の3ステップで
+ * ユーザーの現在地と次にすべきことを常に提示するための定義。
+ * StepFlowBar コンポーネントと App / EditorScreen / UploadScreen が参照する。
+ */
+
+export type FlowStepId = 'input' | 'review' | 'export'
+
+export type FlowStepStatus = 'done' | 'current' | 'upcoming'
+
+export interface FlowStep {
+  id: FlowStepId
+  num: number
+  /** ステップバーに表示する短いラベル */
+  label: string
+  /** 現在ステップのときに表示する「いまやること」の説明 */
+  action: string
+}
+
+/** アプリ全体のゴール（ステップバーのツールチップ等で表示） */
+export const FLOW_GOAL = '個人情報をマスクした経歴書を書き出す'
+
+export const FLOW_STEPS: FlowStep[] = [
+  {
+    id: 'input',
+    num: 1,
+    label: '取り込む',
+    action: 'ファイルを選択（またはドラッグ＆ドロップ）。まずはサンプルでもOK',
+  },
+  {
+    id: 'review',
+    num: 2,
+    label: '確認する',
+    action: '検出された個人情報を確認し、不要な項目はオフにする',
+  },
+  {
+    id: 'export',
+    num: 3,
+    label: '書き出す',
+    action: '形式を選んで保存、またはコピーする',
+  },
+]
+
+/** アプリ状態から現在のステップを判定する */
+export function getCurrentFlowStep(state: { hasData: boolean; exportOpen: boolean }): FlowStepId {
+  if (!state.hasData) return 'input'
+  return state.exportOpen ? 'export' : 'review'
+}
+
+/** あるステップが現在地に対して done / current / upcoming のどれかを返す */
+export function getFlowStepStatus(stepId: FlowStepId, current: FlowStepId): FlowStepStatus {
+  const order = FLOW_STEPS.map((s) => s.id)
+  const stepIdx = order.indexOf(stepId)
+  const currentIdx = order.indexOf(current)
+  if (stepIdx < currentIdx) return 'done'
+  if (stepIdx === currentIdx) return 'current'
+  return 'upcoming'
+}
+
+/**
+ * ステップバー ⇔ 各画面間の連携イベント名
+ *
+ * モノリス構造（RedactPro.tsx）内で props バケツリレーを避けるため、
+ * window の CustomEvent で疎結合に連携する。
+ */
+/** ステップバー → EditorScreen: エクスポートプレビューを開閉する（detail: {open: boolean}） */
+export const FLOW_EVENT_SET_EXPORT = 'sumi:flow-set-export'
+/** EditorScreen → App: エクスポートプレビューの開閉状態を通知（detail: {open: boolean}） */
+export const FLOW_EVENT_EXPORT_STATE = 'sumi:flow-export-state'
+/** UploadScreen → App: 解析中かどうかを通知（detail: {active: boolean}） */
+export const FLOW_EVENT_ANALYZING = 'sumi:flow-analyzing'

--- a/src/lib/flow-steps.ts
+++ b/src/lib/flow-steps.ts
@@ -1,12 +1,13 @@
 /**
  * 作業ステップフロー定義
  *
- * 「取り込む → 確認する → 書き出す」の3ステップで
+ * 「取り込む → 確認する → 整える → 書き出す」の4ステップで
  * ユーザーの現在地と次にすべきことを常に提示するための定義。
+ * 各ステップの画面は単一目的（確認する=PII確認のみ / 整える=レイアウト調整のみ）。
  * StepFlowBar コンポーネントと App / EditorScreen / UploadScreen が参照する。
  */
 
-export type FlowStepId = 'input' | 'review' | 'export'
+export type FlowStepId = 'input' | 'review' | 'format' | 'export'
 
 export type FlowStepStatus = 'done' | 'current' | 'upcoming'
 
@@ -20,7 +21,7 @@ export interface FlowStep {
 }
 
 /** アプリ全体のゴール（ステップバーのツールチップ等で表示） */
-export const FLOW_GOAL = '個人情報をマスクした経歴書を書き出す'
+export const FLOW_GOAL = '個人情報をマスクした、整った経歴書を書き出す'
 
 export const FLOW_STEPS: FlowStep[] = [
   {
@@ -36,17 +37,28 @@ export const FLOW_STEPS: FlowStep[] = [
     action: '検出された個人情報を確認し、不要な項目はオフにする',
   },
   {
-    id: 'export',
+    id: 'format',
     num: 3,
+    label: '整える',
+    action: 'A4プレビューで仕上がりを確認し、レイアウトを整える',
+  },
+  {
+    id: 'export',
+    num: 4,
     label: '書き出す',
     action: '形式を選んで保存、またはコピーする',
   },
 ]
 
 /** アプリ状態から現在のステップを判定する */
-export function getCurrentFlowStep(state: { hasData: boolean; exportOpen: boolean }): FlowStepId {
+export function getCurrentFlowStep(state: {
+  hasData: boolean
+  exportOpen: boolean
+  formatMode?: boolean
+}): FlowStepId {
   if (!state.hasData) return 'input'
-  return state.exportOpen ? 'export' : 'review'
+  if (state.exportOpen) return 'export'
+  return state.formatMode ? 'format' : 'review'
 }
 
 /** あるステップが現在地に対して done / current / upcoming のどれかを返す */
@@ -71,3 +83,7 @@ export const FLOW_EVENT_SET_EXPORT = 'sumi:flow-set-export'
 export const FLOW_EVENT_EXPORT_STATE = 'sumi:flow-export-state'
 /** UploadScreen → App: 解析中かどうかを通知（detail: {active: boolean}） */
 export const FLOW_EVENT_ANALYZING = 'sumi:flow-analyzing'
+/** ステップバー → EditorScreen: 表示モードを切り替える（detail: {mode: 'review'|'format'}） */
+export const FLOW_EVENT_SET_MODE = 'sumi:flow-set-mode'
+/** EditorScreen → App: 現在の表示モードを通知（detail: {mode: 'review'|'format'}） */
+export const FLOW_EVENT_MODE_STATE = 'sumi:flow-mode-state'

--- a/src/lib/intro-steps.ts
+++ b/src/lib/intro-steps.ts
@@ -15,9 +15,9 @@ export interface IntroStep {
 /** ステップフローバー紹介（全ツアー共通の先頭ステップ） */
 const STEP_FLOW_INTRO: IntroStep = {
   element: '[data-intro="step-flow"]',
-  title: '3ステップで完了',
+  title: '4ステップで完了',
   intro:
-    'Sumiの作業は「1 取り込む → 2 確認する → 3 書き出す」の3ステップだけ。今いるステップと、いまやることが常にここに表示されます。',
+    'Sumiの作業は「1 取り込む → 2 確認する → 3 整える → 4 書き出す」の4ステップだけ。今いるステップと、いまやることが常にここに表示されます。',
   position: 'bottom',
 }
 
@@ -116,7 +116,7 @@ export const EDITOR_STEPS_LITE: IntroStep[] = [
     element: '[data-intro="step-flow"]',
     title: 'ステップ2: 確認する',
     intro:
-      '検出結果の確認画面です。確認が済んだら「3 書き出す」をクリックするとエクスポートに進めます。',
+      '検出結果の確認画面です。確認が済んだら「次へ: 整える」でA4プレビューに進み、最後に「4 書き出す」でエクスポートします。',
     position: 'bottom',
   },
   {
@@ -138,9 +138,10 @@ export const EDITOR_STEPS_LITE: IntroStep[] = [
     position: 'left',
   },
   {
-    element: '[data-intro="export-buttons"]',
-    title: 'エクスポート',
-    intro: 'テキスト・Markdown・CSV・Excel・PDF・Wordの6形式で出力できます。',
+    element: '[data-intro="go-format"]',
+    title: '次へ: 整える',
+    intro:
+      '確認が済んだらこのボタンでA4プレビューへ。仕上がりを確認してから、テキスト・Markdown・CSV・Excel・PDF・Wordの6形式で書き出せます。',
     position: 'top',
   },
 ]
@@ -153,7 +154,7 @@ export const EDITOR_STEPS_PRO: IntroStep[] = [
     element: '[data-intro="step-flow"]',
     title: 'ステップ2: 確認する',
     intro:
-      '検出結果の確認画面です。確認が済んだら「3 書き出す」をクリックするとエクスポートに進めます。',
+      '検出結果の確認画面です。確認が済んだら「次へ: 整える」でA4プレビューに進み、最後に「4 書き出す」でエクスポートします。',
     position: 'bottom',
   },
   {
@@ -199,22 +200,10 @@ export const EDITOR_STEPS_PRO: IntroStep[] = [
     position: 'left',
   },
   {
-    element: '[data-intro="ai-reformat"]',
-    title: 'AI再フォーマット',
-    intro: 'AIがマスキング済みテキストを推薦書やスキルシートなどの形式に自動整形します。',
-    position: 'left',
-  },
-  {
-    element: '[data-intro="pdf-edit"]',
-    title: 'PDFプレビュー・編集',
-    intro: 'A4レイアウトでプレビュー。テキストを直接編集してPDF出力できます。',
-    position: 'left',
-  },
-  {
-    element: '[data-intro="export-buttons"]',
-    title: '書き出し',
+    element: '[data-intro="go-format"]',
+    title: '次へ: 整える',
     intro:
-      '「次へ: 書き出す」でプレビューを確認し、6形式（Text / Markdown / CSV / Excel / PDF / Word）で保存できます。コピーもこちらから。',
+      '確認が済んだらこのボタンでA4プレビューへ。テキスト直接編集・AI再フォーマット（推薦書/スキルシート等）もそこで行い、最後に6形式（Text / Markdown / CSV / Excel / PDF / Word）で書き出せます。',
     position: 'top',
   },
   {

--- a/src/lib/intro-steps.ts
+++ b/src/lib/intro-steps.ts
@@ -12,10 +12,20 @@ export interface IntroStep {
   position?: 'top' | 'bottom' | 'left' | 'right'
 }
 
+/** ステップフローバー紹介（全ツアー共通の先頭ステップ） */
+const STEP_FLOW_INTRO: IntroStep = {
+  element: '[data-intro="step-flow"]',
+  title: '3ステップで完了',
+  intro:
+    'Sumiの作業は「1 取り込む → 2 確認する → 3 書き出す」の3ステップだけ。今いるステップと、いまやることが常にここに表示されます。',
+  position: 'bottom',
+}
+
 /**
  * Lite版 UploadScreen ステップ
  */
 export const UPLOAD_STEPS_LITE: IntroStep[] = [
+  STEP_FLOW_INTRO,
   {
     element: '[data-intro="upload-zone"]',
     title: 'ファイルアップロード',
@@ -47,6 +57,7 @@ export const UPLOAD_STEPS_LITE: IntroStep[] = [
  * Pro版 UploadScreen ステップ
  */
 export const UPLOAD_STEPS_PRO: IntroStep[] = [
+  STEP_FLOW_INTRO,
   {
     element: '[data-intro="upload-zone"]',
     title: 'ファイルアップロード',
@@ -102,6 +113,13 @@ export const UPLOAD_STEPS_PRO: IntroStep[] = [
  */
 export const EDITOR_STEPS_LITE: IntroStep[] = [
   {
+    element: '[data-intro="step-flow"]',
+    title: 'ステップ2: 確認する',
+    intro:
+      '検出結果の確認画面です。確認が済んだら「3 書き出す」をクリックするとエクスポートに進めます。',
+    position: 'bottom',
+  },
+  {
     element: '[data-intro="view-tabs"]',
     title: '表示モード',
     intro: '「マスク」で置換後テキスト、「Diff」で変更前後の差分を確認できます。',
@@ -131,6 +149,13 @@ export const EDITOR_STEPS_LITE: IntroStep[] = [
  * Pro版 EditorScreen ステップ
  */
 export const EDITOR_STEPS_PRO: IntroStep[] = [
+  {
+    element: '[data-intro="step-flow"]',
+    title: 'ステップ2: 確認する',
+    intro:
+      '検出結果の確認画面です。確認が済んだら「3 書き出す」をクリックするとエクスポートに進めます。',
+    position: 'bottom',
+  },
   {
     element: '[data-intro="view-tabs"]',
     title: '表示モード',
@@ -187,8 +212,9 @@ export const EDITOR_STEPS_PRO: IntroStep[] = [
   },
   {
     element: '[data-intro="export-buttons"]',
-    title: 'プレビュー / 保存',
-    intro: 'マスキング結果のプレビュー表示やクリップボードコピーはこちらから。',
+    title: '書き出し',
+    intro:
+      '「次へ: 書き出す」でプレビューを確認し、6形式（Text / Markdown / CSV / Excel / PDF / Word）で保存できます。コピーもこちらから。',
     position: 'top',
   },
   {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',


### PR DESCRIPTION
## 概要

「フローが複雑で初めてのユーザーが使いこなせない」という課題への改善。アプリ全体を「**1 取り込む → 2 確認する → 3 整える → 4 書き出す**」の4ステップに再構成し、各ステップの画面を単一目的化した。ユーザーが今どこにいて次に何をすべきかが常に一目で分かり、各画面の主ボタンは「次へ」1つに統一されている。

## 変更内容

### ステップフローバー（新設・全画面共通）
- ヘッダー直下に4ステップのバーを常時表示。現在ステップを強調、完了ステップは緑チェック
- 右側に「いまやること」として現在ステップの具体的アクションを1文で提示。解析中は進行状況の案内に切替
- バー自体が導線: 各ステップをクリックして確認/整える/書き出しを直接切替。「1 取り込む」は確認ダイアログ付きのやり直し
- バッチ処理中など編集画面が未表示の間は「整える/書き出す」を無効化しツールチップで案内

### 画面の単一目的化
- **確認する**: マスク済みテキスト＋検出リストのみ（A4プレビューはデフォルト非表示）。PII確認に専念し、主ボタンは「次へ: 整える」
- **整える**（新設）: A4プレビュー専用ビュー。**Lite版にも開放**し、KPIである「整った経歴書」を全ユーザーが確認可能に。ProはMarkdown直接編集・フォント切替・AI再フォーマット・全画面編集をここに集約。主ボタンは「次へ: 書き出す」
- **書き出す**: エクスポートプレビュー（6形式）。編集モードの`editedText`も正しく反映

### オンボーディング連携
- 初回ガイドツアー（Lite/Pro × アップロード/エディタ全4種）を4ステップ構成に合わせて更新

### 実装構成
- ステップ定義・判定ロジックは型安全な `src/lib/flow-steps.ts` に切り出し（テスト11件付き）
- UIは `src/components/StepFlowBar.tsx` + CSS Module。テーマ（ダーク/ライト）対応、モバイルはヒント非表示に縮退
- モノリス（RedactPro.tsx）とは CustomEvent（開閉・モード・解析状態）で疎結合に連携
- ステップバー分の高さ（40px）を各画面のレイアウト計算に反映
- vitest に `@` エイリアス設定を追加

## レビュー対応

- CodeRabbit指摘3件（editedText未反映 / バッチ処理中の書き出し無反応 / currentColor小文字化）対応済み

## 検証

- `pnpm build` / `pnpm test`（全462テスト）/ `pnpm type-check` / `pnpm lint` 通過
- ブラウザ実機確認: 取り込む→確認する→整える→書き出す→モーダルを閉じて整えるへ復帰→ステップバーで確認に戻る、の全遷移を確認（Lite版）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATQzdapWugJmQas7469Aux